### PR TITLE
Add Windows support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,10 @@ class YoutubeMusicServer {
                     exec(command, (error: ExecException | null, stdout: string, stderr: string) => {
                         if (error) {
                             this.log.push(`Error opening song in Chrome: ${error.message}`);
-                            console.error(`Error opening Chrome: ${error.message}`);
+                            throw new McpError(
+                                ErrorCode.InternalError, 
+                                `Error opening song in Chrome: ${error.message}`
+                            );
                         } else {
                             this.log.push(`Opened song in Chrome: ${youtubeMusicUrl}`);
                         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node16",
     "outDir": "./build",
     "rootDir": "./src",
+    "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Note: I verified that it works on Windows, but did not test Mac after the change. Assuming that `os.platform() === 'darwin'` is correct for Mac, it should be ok.